### PR TITLE
KDE KF6 update

### DIFF
--- a/org.kde.granatier.json
+++ b/org.kde.granatier.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.granatier",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-23.08",
+    "runtime-version": "6.6",
     "sdk": "org.kde.Sdk",
     "command": "granatier",
     "rename-icon": "granatier",

--- a/org.kde.granatier.json
+++ b/org.kde.granatier.json
@@ -20,8 +20,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/libkdegames-23.08.5.tar.xz",
-                    "sha256": "0ac583f4327d6003782054a9ee3d51c922bcdf04577a3f7f12b3840cabf2efed",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/libkdegames-24.02.0.tar.xz",
+                    "sha256": "3d113422dc654348b2025de5fe1de256d06a3c55be9c7b104253e25595b2e2b1",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,
@@ -37,8 +37,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/granatier-23.08.5.tar.xz",
-                    "sha256": "f0074a621df9960d62ba0d4b8f817a592f3d02fdd243328549e9a544346729ee",
+                    "url": "https://download.kde.org/stable/release-service/24.02.0/src/granatier-24.02.0.tar.xz",
+                    "sha256": "4c17c5b467a8cc23dcf3eca34216afe04dbd6b5d22c4b81fb9ff099e52517131",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,


### PR DESCRIPTION
Update libkdegames-23.08.5.tar.xz to 24.02.0
Update granatier-23.08.5.tar.xz to 24.02.0